### PR TITLE
Fix link_local separator

### DIFF
--- a/network.go
+++ b/network.go
@@ -21,7 +21,7 @@ type IPv6Data struct {
 	SLAAC        netip.Prefix   `json:"slaac"`
 	LinkLocal    netip.Prefix   `json:"link_local"`
 	Ranges       []netip.Prefix `json:"ranges"`
-	SharedRanges []netip.Prefix `json:"shared-ranges"`
+	SharedRanges []netip.Prefix `json:"shared_ranges"`
 }
 
 type NetworkData struct {


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**
LinkLocal is returned with an `_` not a `-`

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**
