### PR TITLE
ref: (BREAKING) Use map for Client.GetSSHKeys(...) response

### DIFF
--- a/examples/instancewatcher/main.go
+++ b/examples/instancewatcher/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"context"
-	metadata "github.com/linode/go-metadata"
 	"log"
 	"time"
+
+	metadata "github.com/linode/go-metadata"
 )
 
 func main() {

--- a/examples/networkwatcher/main.go
+++ b/examples/networkwatcher/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"context"
-	metadata "github.com/linode/go-metadata"
 	"log"
 	"time"
+
+	metadata "github.com/linode/go-metadata"
 )
 
 func main() {

--- a/sshkeys.go
+++ b/sshkeys.go
@@ -2,16 +2,10 @@ package metadata
 
 import "context"
 
-// SSHKeysUserData contains per-user SSH public keys
-// specified during Linode instance/disk creation.
-type SSHKeysUserData struct {
-	Root []string `json:"root"`
-}
-
 // SSHKeysData contains information about SSH keys
 // relevant to the current Linode instance.
 type SSHKeysData struct {
-	Users SSHKeysUserData `json:"users"`
+	Users map[string][]string `json:"users"`
 }
 
 // GetSSHKeys gets all SSH keys for the current instance.

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -2,10 +2,11 @@ package integration
 
 import (
 	"context"
-	"github.com/linode/go-metadata"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/linode/go-metadata"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_UnmanagedTokenExpired(t *testing.T) {

--- a/test/integration/helper_test.go
+++ b/test/integration/helper_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/linode/linodego"
 )
 
-var testToken = os.Getenv("LINODE_TOKEN")
-var metadataClient *metadata.Client
-var linodeClient *linodego.Client
+var (
+	testToken      = os.Getenv("LINODE_TOKEN")
+	metadataClient *metadata.Client
+	linodeClient   *linodego.Client
+)
 
 func init() {
 	if testToken == "" {

--- a/test/integration/instance_test.go
+++ b/test/integration/instance_test.go
@@ -2,8 +2,9 @@ package integration
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetInstance(t *testing.T) {

--- a/test/integration/sshkeys_test.go
+++ b/test/integration/sshkeys_test.go
@@ -15,7 +15,7 @@ func TestGetSSHKeys(t *testing.T) {
 
 	if len(sshKeys.Users) < 1 {
 		t.Skip(
-			"The current instance does not have any any SSH keys configured, skipping...")
+			"The current instance does not have any SSH keys configured, skipping...")
 	}
 
 	for _, v := range sshKeys.Users {

--- a/test/integration/sshkeys_test.go
+++ b/test/integration/sshkeys_test.go
@@ -2,22 +2,22 @@ package integration
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-// NOTE: This test assumes the host instance has
-// a user configured with SSH keys. This should
-// always be the case when using the `make e2e`
-// target but may not always be the case when running
-// the `make e2e-local` target.
 func TestGetSSHKeys(t *testing.T) {
 	t.Parallel()
 
 	sshKeys, err := metadataClient.GetSSHKeys(context.Background())
 	assert.NoError(t, err)
 
-	assert.Greater(t, len(sshKeys.Users), 0)
+	if len(sshKeys.Users) < 1 {
+		t.Skip(
+			"The current instance does not have any any SSH keys configured, skipping...")
+	}
+
 	for _, v := range sshKeys.Users {
 		assert.Greater(t, len(v), 0)
 	}

--- a/test/integration/sshkeys_test.go
+++ b/test/integration/sshkeys_test.go
@@ -1,0 +1,24 @@
+package integration
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// NOTE: This test assumes the host instance has
+// a user configured with SSH keys. This should
+// always be the case when using the `make e2e`
+// target but may not always be the case when running
+// the `make e2e-local` target.
+func TestGetSSHKeys(t *testing.T) {
+	t.Parallel()
+
+	sshKeys, err := metadataClient.GetSSHKeys(context.Background())
+	assert.NoError(t, err)
+
+	assert.Greater(t, len(sshKeys.Users), 0)
+	for _, v := range sshKeys.Users {
+		assert.Greater(t, len(v), 0)
+	}
+}

--- a/test/integration/userdata_test.go
+++ b/test/integration/userdata_test.go
@@ -2,8 +2,9 @@ package integration
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetUserData(t *testing.T) {


### PR DESCRIPTION
## 📝 Description

This change updates the response struct for `Client.GetSSHKeys(...)` to return a `map[string][]string` rather than the `SSHKeysUserData` struct. This is necessary because the MDS API can return SSH keys for arbitrary users configured using cloud-config.

## ✔️ How to Test

The following test steps assume you have pulled this branch down locally.

E2E Testing:

```go
make e2e
```

Manual Testing: 

**TODO**
