### PR TITLE
new: Add support for opt-in debug logging

### DIFF
--- a/examples/instancewatcher/main.go
+++ b/examples/instancewatcher/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"context"
-	metadata "github.com/linode/go-metadata"
 	"log"
 	"time"
+
+	metadata "github.com/linode/go-metadata"
 )
 
 func main() {

--- a/examples/networkwatcher/main.go
+++ b/examples/networkwatcher/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"context"
-	metadata "github.com/linode/go-metadata"
 	"log"
 	"time"
+
+	metadata "github.com/linode/go-metadata"
 )
 
 func main() {

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -2,10 +2,11 @@ package integration
 
 import (
 	"context"
-	"github.com/linode/go-metadata"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/linode/go-metadata"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_UnmanagedTokenExpired(t *testing.T) {
@@ -41,4 +42,25 @@ func TestClient_ManagedTokenRefresh(t *testing.T) {
 	// Token should have automatically refreshed
 	_, err = mdClient.GetInstance(context.Background())
 	assert.NoError(t, err)
+}
+
+func TestClient_DebugLogs(t *testing.T) {
+	var logger testLogger
+
+	mdClient, err := metadata.NewClient(
+		context.Background(),
+		metadata.ClientWithDebug(),
+		metadata.ClientWithLogger(&logger),
+	)
+	assert.NoError(t, err)
+
+	_, err = mdClient.GetInstance(context.Background())
+	assert.NoError(t, err)
+
+	debugOutput := logger.Data.String()
+
+	// Validate a few arbitrary bits of the debug output
+	assert.Contains(t, debugOutput, "User-Agent: go-metadata")
+	assert.Contains(t, debugOutput, "/v1/token")
+	assert.Contains(t, debugOutput, "/v1/instance")
 }

--- a/test/integration/helper_test.go
+++ b/test/integration/helper_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/linode/linodego"
 )
 
-var testToken = os.Getenv("LINODE_TOKEN")
-var metadataClient *metadata.Client
-var linodeClient *linodego.Client
+var (
+	testToken      = os.Getenv("LINODE_TOKEN")
+	metadataClient *metadata.Client
+	linodeClient   *linodego.Client
+)
 
 func init() {
 	if testToken == "" {

--- a/test/integration/instance_test.go
+++ b/test/integration/instance_test.go
@@ -2,8 +2,9 @@ package integration
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetInstance(t *testing.T) {

--- a/test/integration/userdata_test.go
+++ b/test/integration/userdata_test.go
@@ -2,8 +2,9 @@ package integration
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetUserData(t *testing.T) {

--- a/test/integration/util_test.go
+++ b/test/integration/util_test.go
@@ -1,0 +1,22 @@
+package integration
+
+import (
+	"bytes"
+	"fmt"
+)
+
+type testLogger struct {
+	Data bytes.Buffer
+}
+
+func (l *testLogger) Errorf(format string, v ...interface{}) {
+	l.Data.WriteString("[ERROR] " + fmt.Sprintf(format, v...))
+}
+
+func (l *testLogger) Warnf(format string, v ...interface{}) {
+	l.Data.WriteString("[WARN] " + fmt.Sprintf(format, v...))
+}
+
+func (l *testLogger) Debugf(format string, v ...interface{}) {
+	l.Data.WriteString("[DEBUG] " + fmt.Sprintf(format, v...))
+}


### PR DESCRIPTION
## 📝 Description

This change adds support for opt-in MDS API request/response logging as well as the ability to configure a custom logger. 

Debug logging for a metadata client can be configured using the `ClientWithDebug` and `ClientWithLogger` client creation options which configure Resty's built-in debug logging under the hood.

NOTE: Unlike linodego's implementation debug mode cannot directly be enabled from the environment and cannot be updated once the client has been created. These were intentional choices made to prevent any unexpected or confusing behavior.

## ✔️ How to Test

The following test steps assume you have pulled down this change locally.

### E2E Testing

```bash
make e2e
```

### Manual Testing

The following tests should be run in a go-metadata sandbox environment (e.g. dx-devenv).

#### With Default Logger

1. Run the following Go code:

```go
package main

import (
	"context"
	"fmt"
	metadata "github.com/linode/go-metadata"
	"log"
)

func main() {
	client, err := metadata.NewClient(
		context.Background(),
		metadata.ClientWithDebug(), 
	)
	if err != nil {
		log.Fatal(err)
	}

	_, err = client.GetInstance(context.Background())
	if err != nil {
		log.Fatal(err)
	}
}
```

2. Observe that the PUT /v1/token and GET /v1/instance requests have been logged to the console.

#### With Custom Logger

1. Run the following Go code:

```go
package main

import (
	"bytes"
	"context"
	"fmt"
	metadata "github.com/linode/go-metadata"
	"log"
)

type customLogger struct {
	Data bytes.Buffer
}

func (l *customLogger) Errorf(format string, v ...interface{}) {
	l.Data.WriteString("[ERROR] " + fmt.Sprintf(format, v...))
}

func (l *customLogger) Warnf(format string, v ...interface{}) {
	l.Data.WriteString("[WARN] " + fmt.Sprintf(format, v...))
}

func (l *customLogger) Debugf(format string, v ...interface{}) {
	l.Data.WriteString("[DEBUG] " + fmt.Sprintf(format, v...))
}

func main() {
	var logger customLogger

	client, err := metadata.NewClient(
		context.Background(),
		metadata.ClientWithDebug(),
		metadata.ClientWithLogger(&logger),
	)
	if err != nil {
		log.Fatal(err)
	}

	_, err = client.GetInstance(context.Background())
	if err != nil {
		log.Fatal(err)
	}

	fmt.Println("DISPLAY BEFORE LOGS")
	fmt.Println("Logs:", logger.Data.String())
}
```

2. Observe that the `DISPLAY BEFORE LOGS` message is displayed before the log buffer is printed.
3. Observe that the PUT /v1/token and GET /v1/instance requests have been printed to the console.


