### PR TITLE
Fix e2e workflow

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -17,23 +17,19 @@ jobs:
     steps:
       - name: checkout repo
         uses: actions/checkout@v4
-        if: ${{ inputs.commit_sha != '' }}
         with:
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 0
           submodules: 'recursive'
 
-      - name: update packages
-        run: sudo apt-get update -y
-
       - name: setup python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: install or update Python build system
         run: python3 -m pip install -U wheel setuptools certifi pip
-    
+
       - name: install test dependencies
         run: make test-deps
 


### PR DESCRIPTION
## 📝 Description

This is to fix the E2E workflow

## ✔️ How to Test
Test result: https://github.com/zliang-akamai/go-metadata/actions/runs/11506089637/job/32029239414
The failure above was caused by TOD uploading, rather than E2E itself, because I can't setup TOD in my fork.