### PR TITLE
TPT-4483: Fix e2e test error caused by new pubkey/password validation

### DIFF
--- a/hack/run-e2e.yml
+++ b/hack/run-e2e.yml
@@ -49,6 +49,8 @@
         type: "{{ type }}"
         region: "{{ region }}"
         image: linode/ubuntu24.04
+        authorized_keys:
+          - "{{ ssh_pubkey }}"
         booted: true
         metadata:
           user_data: '{{ lookup("template", playbook_dir ~ "/harden.yaml.j2") }}'
@@ -188,4 +190,3 @@
       assert:
         that:
           - "'ansible_failed_result' not in hostvars['test-runner']"
-    

--- a/hack/run-e2e.yml
+++ b/hack/run-e2e.yml
@@ -50,7 +50,7 @@
         region: "{{ region }}"
         image: linode/ubuntu24.04
         authorized_keys:
-          - "{{ ssh_pubkey }}"
+          - "{{ ssh_pubkey | trim }}"
         booted: true
         metadata:
           user_data: '{{ lookup("template", playbook_dir ~ "/harden.yaml.j2") }}'


### PR DESCRIPTION
## 📝 Description

This pull request resolves an issue that was causing CI to fail due to validation changes made alongside SLADE + CLEO.

## ✔️ How to Test

Sample CI run: https://github.com/lgarber-akamai/go-metadata/actions/runs/26843064992/job/79155178875